### PR TITLE
Added collision logic for walls and tanks

### DIFF
--- a/source/level/LevelGenerator.hx
+++ b/source/level/LevelGenerator.hx
@@ -27,23 +27,15 @@ class LevelGenerator {
 	private static var BITMAP_INDEX_EMPTY(default, never):Int = 0;
 	private static var BITMAP_INDEX_WALL(default, never):Int = 1;
 
-	// Instantiating Instance Variables
-	private var mapWidth:Int;
-	private var mapHeight:Int;
-
-	public function new(?mapWidth:Int = 20, ?mapHeight:Int = 20) {
-		this.mapWidth = mapWidth;
-		this.mapHeight = mapHeight;
-	}
-
 	/**
 	 * Creates a randomly generated level in the form of a 2D Array
 	 * @return Array<Array<Int>>	Level map
 	 */
-	public function generateLevel():Array<Array<Int>> {
-		var map = instantiateMap();
-		map = addBordersToMap(map);
-		map = addObstaclesToMap(map);
+	public static function generateLevel(?mapWidth:Int = 20,
+			?mapHeight:Int = 20):Array<Array<Int>> {
+		var map = instantiateMap(mapWidth, mapHeight);
+		map = addBordersToMap(map, mapWidth, mapHeight);
+		map = addObstaclesToMap(map, mapWidth, mapHeight);
 
 		return map;
 	}
@@ -51,11 +43,11 @@ class LevelGenerator {
 	/**
 	 * Populates this.map with an empty 2D Array with width and height specified previously
 	 */
-	private function instantiateMap():Array<Array<Int>> {
-		return [for (x in 0...this.mapWidth) [for (y in 0...this.mapHeight) BITMAP_INDEX_EMPTY]];
+	private static function instantiateMap(mapWidth:Int, mapHeight:Int):Array<Array<Int>> {
+		return [for (x in 0...mapWidth) [for (y in 0...mapHeight) BITMAP_INDEX_EMPTY]];
 	}
 
-	private function addBordersToMap(map:Array<Array<Int>>) {
+	private static function addBordersToMap(map:Array<Array<Int>>, mapWidth:Int, mapHeight:Int) {
 		// Add borders on sides
 		for (row in map) {
 			row[0] = BITMAP_INDEX_WALL;
@@ -63,18 +55,18 @@ class LevelGenerator {
 		}
 
 		// Replace all items in first and last rows with walls
-		map[0] = [for (_ in 0...this.mapWidth) BITMAP_INDEX_WALL];
-		map[map.length - 1] = [for (_ in 0...this.mapWidth) BITMAP_INDEX_WALL];
+		map[0] = [for (_ in 0...mapWidth) BITMAP_INDEX_WALL];
+		map[map.length - 1] = [for (_ in 0...mapWidth) BITMAP_INDEX_WALL];
 
 		return map;
 	}
 
-	private function addObstaclesToMap(map:Array<Array<Int>>) {
+	private static function addObstaclesToMap(map:Array<Array<Int>>, mapWidth:Int, mapHeight:Int) {
 		// Define bounds for borders
 		var minX = MIN_GAP_SIZE_X;
 		var minY = MIN_GAP_SIZE_Y;
-		var maxX = this.mapWidth - 1 - MIN_GAP_SIZE_X;
-		var maxY = this.mapHeight - 1 - MIN_GAP_SIZE_Y;
+		var maxX = mapWidth - 1 - MIN_GAP_SIZE_X;
+		var maxY = mapHeight - 1 - MIN_GAP_SIZE_Y;
 
 		var random = FlxG.random;
 
@@ -121,8 +113,8 @@ class LevelGenerator {
 		return map;
 	}
 
-	private function drawWall(map:Array<Array<Int>>, startingPoint:FlxPoint, finalPoint:FlxPoint,
-			direction:Direction) {
+	private static function drawWall(map:Array<Array<Int>>, startingPoint:FlxPoint,
+			finalPoint:FlxPoint, direction:Direction) {
 		switch (direction) {
 			case Up | Down:
 				for (y in Std.int(startingPoint.y)...Std.int(finalPoint.y)) {

--- a/source/level/TestGenState.hx
+++ b/source/level/TestGenState.hx
@@ -1,30 +1,57 @@
 package level;
 
+import flixel.FlxG;
 import flixel.FlxState;
+import flixel.group.FlxGroup;
 import flixel.tile.FlxTilemap;
 import level.LevelGenerator;
+import tank.Tank;
+import tank.TankFactory;
 
 class TestGenState extends FlxState {
 	private static var TILE_HEIGHT(default, never):Int = 32;
 	private static var TILE_WIDTH(default, never):Int = 32;
 
-	private static var LEVEL_HEIGHT(default, never):Int = 32;
-	private static var LEVEL_WIDTH(default, never):Int = 32;
+	private static var LEVEL_HEIGHT(default, never):Int = 20;
+	private static var LEVEL_WIDTH(default, never):Int = 20;
+
+	private var map:FlxTilemap;
+
+	private var playerTank:Tank;
+	private var enemyTanks:FlxTypedGroup<Tank>;
 
 	override public function create() {
 		super.create();
 
-		var gen = new LevelGenerator(20, 20);
-		var bitmap = gen.generateLevel();
+		var bitmap = LevelGenerator.generateLevel(LEVEL_HEIGHT, LEVEL_WIDTH);
 
-		var map = new FlxTilemap();
-		trace(bitmap);
+		map = new FlxTilemap();
 		map.loadMapFrom2DArray(bitmap, AssetPaths.Wall__png, TILE_WIDTH, TILE_HEIGHT);
 
 		add(map);
+		addTanks();
 	}
 
 	override public function update(elapsed:Float) {
 		super.update(elapsed);
+
+		FlxG.collide(playerTank, map);
+		FlxG.collide(enemyTanks, map);
+	}
+
+	private function addTanks() {
+		var tankCoordinates = [250, 300, 350];
+		playerTank = TankFactory.NewPlayerTank(500, 500);
+
+		enemyTanks = new FlxTypedGroup<Tank>(3);
+		for (x in tankCoordinates) {
+			var enemy = TankFactory.NewDumbTank(x, 50);
+			enemyTanks.add(enemy);
+		}
+
+		add(playerTank.getAllSprites());
+		for (enemyTank in enemyTanks) {
+			add(enemyTank.getAllSprites());
+		}
 	}
 }


### PR DESCRIPTION
Added logic to check for collisions between enemy/player tanks and walls, as well as changed LevelGeneration to a static call. Anything I created in the TestGenState is temporary, and the collision logic will just be moved over to PlayState when that is finished.